### PR TITLE
fix: Update color class mapping for prescription status indicator in …

### DIFF
--- a/frontend/src/features/customer/components/DashboardCards/CurrentPrescriptionsCard.jsx
+++ b/frontend/src/features/customer/components/DashboardCards/CurrentPrescriptionsCard.jsx
@@ -51,7 +51,7 @@ const CurrentPrescriptionsCard = () => {
             <div className="flex justify-between">
               <div className="flex-1">
                 <div className="flex items-center">
-                  <div className={`w-2 h-2 rounded-full ${colorClassMap[prescription.color]} mr-2`}></div>
+                  <div className={`w-2 h-2 rounded-full bg-${prescription.color}-400 mr-2`}></div>
                   <h4 className="text-white font-medium">{prescription.name}</h4>
                 </div>
                 


### PR DESCRIPTION
This pull request includes a minor change to the `CurrentPrescriptionsCard` component in the `frontend` codebase. The change updates the way prescription colors are applied to the indicator dot.

Styling update:

* [`frontend/src/features/customer/components/DashboardCards/CurrentPrescriptionsCard.jsx`](diffhunk://#diff-f31f866b6a4c20d7c067968bf06101762a88856dd1e323f5c1692cacc9b125fcL54-R54): Replaced the use of the `colorClassMap` object with a Tailwind CSS utility class (`bg-${prescription.color}-400`) for dynamically applying the prescription color.…CurrentPrescriptionsCard